### PR TITLE
Added note about required frontmatter in CSS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ plugins:
 
 Make sure you have [postcss-cli](https://github.com/postcss/postcss-cli) installed and has its binary located at `./node_modules/.bin/postcss`.
 
-Add your PostCSS plugins to a `postcss.config.js` file in the root of your repository. 
+Add your PostCSS plugins to a `postcss.config.js` file in the root of your repository.
 
 ```javascript
 // postcss.config.js

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ plugins:
 
 Make sure you have [postcss-cli](https://github.com/postcss/postcss-cli) installed and has its binary located at `./node_modules/.bin/postcss`.
 
-Add your PostCSS plugins to a `postcss.config.js` file in the root of your repository.
+Add your PostCSS plugins to a `postcss.config.js` file in the root of your repository. 
 
 ```javascript
 // postcss.config.js
@@ -44,6 +44,18 @@ All files with the `.css` extension will now be processed by PostCSS.
 ### Note
 
 `jekyll-postcss` will cache your styles to avoid rebuilding when nothing has changed.
+
+Also note that your `.css` files still need to have a frontmatter (top part separated with `---`) for them to be processed by jekyll.
+
+```
+---
+---
+
+/* Example using Tailwind */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ All files with the `.css` extension will now be processed by PostCSS.
 
 `jekyll-postcss` will cache your styles to avoid rebuilding when nothing has changed.
 
-Also note that your `.css` files still need to have a frontmatter (top part separated with `---`) for them to be processed by jekyll.
+Also note that your `.css` files still need to have a [front matter](https://jekyllrb.com/docs/step-by-step/03-front-matter/) for them to be processed by Jekyll.
 
 ```
 ---


### PR DESCRIPTION
This gives an example of a simple CSS file, that will be correctly processed by jekyll-postcss