### PR TITLE
Fix compiled_css in production mode

### DIFF
--- a/lib/jekyll-postcss/socket.rb
+++ b/lib/jekyll-postcss/socket.rb
@@ -2,7 +2,6 @@
 
 require "socket"
 require "json"
-require "open3"
 
 module PostCss
   class Socket
@@ -30,7 +29,7 @@ module PostCss
       else
         raise "You must call PostCss#write before calling PostCss#read" if @compiled_css.nil?
 
-        @compiled_css
+        decode(@compiled_css)
       end
     end
 

--- a/lib/jekyll/converters/postcss.rb
+++ b/lib/jekyll/converters/postcss.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "json"
 require "digest"
 require_relative "../../jekyll-postcss/socket"
 
@@ -44,7 +43,7 @@ module Jekyll
 
         reset
 
-        JSON.parse(@converted_cache)["compiled_css"]
+        @converted_cache
       end
 
       private

--- a/lib/jekyll/converters/postcss.rb
+++ b/lib/jekyll/converters/postcss.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "digest"
 require_relative "../../jekyll-postcss/socket"
 
@@ -43,7 +44,7 @@ module Jekyll
 
         reset
 
-        @converted_cache
+        JSON.parse(@converted_cache)["compiled_css"]
       end
 
       private


### PR DESCRIPTION
In both versions 0.3.0 and 0.3.1, the css outputted (in production mode only) is actually a json blob like `{"compiled_css": "...css code..."}`. This seems like a bug. I'm not sure if this is the best way to fix it (or if it should be fixed on the JS side instead), but this fixes it for me at least