### PR TITLE
Output full PostCSS error details, not just the message

### DIFF
--- a/bin/postcss
+++ b/bin/postcss
@@ -11,7 +11,7 @@ class PostCSS {
       .then((result) => write(result))
       .catch((error) => {
         console.error("PostCSS Error!\n");
-        console.error(error.toString());
+        console.error(error);
       });
   }
 


### PR DESCRIPTION
## Purpose
While running this gem, an error was being output but it was hard to debug since only the message was being output the the console.

```
PostCSS Error!

TypeError: Cannot convert undefined or null to object
```

## Summary
By changing this line:

```javascript
console.error("PostCSS Error!\n");
console.error(error.toString());
```

to this:

```javascript
console.error("PostCSS Error!\n");
console.error(error);
```

The error is much more clear, and easier to start debugging:

```
PostCSS Error!

TypeError: Cannot convert undefined or null to object
    at Function.entries (<anonymous>)
    at matchUtilities (/Users/carl/workspace/download/figs-jekyll-theme/node_modules/tailwindcss/lib/util/processPlugins.js:130:37)
    at /Users/carl/workspace/download/figs-jekyll-theme/node_modules/tailwindcss/lib/plugins/blur.js:15:5
    at /Users/carl/workspace/download/figs-jekyll-theme/node_modules/tailwindcss/lib/util/processPlugins.js:97:5
    at Array.forEach (<anonymous>)
    at _default (/Users/carl/workspace/download/figs-jekyll-theme/node_modules/tailwindcss/lib/util/processPlugins.js:91:11)
    at /Users/carl/workspace/download/figs-jekyll-theme/node_modules/tailwindcss/lib/processTailwindFeatures.js:64:54
    at LazyResult.runOnRoot (/Users/carl/workspace/download/figs-jekyll-theme/node_modules/postcss/lib/lazy-result.js:339:16)
    at LazyResult.runAsync (/Users/carl/workspace/download/figs-jekyll-theme/node_modules/postcss/lib/lazy-result.js:391:26)
```
