### PR TITLE
Add configuration option to disable caching.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,17 @@ module.exports = {
 };
 ```
 
+### Caching
+
+Caching is enabled by default so PostCSS will only be called when the CSS content has changed. If needed you can disable caching in your Jekyll configuration to force the CSS to be recompiled every time:
+
+```yaml
+# _config.yml
+
+postcss:
+  cache: false
+```
+
 ### Deployment
 
 When deploying, make sure to set your `JEKYLL_ENV` to something like `production` or `staging`. This is necessary to make sure that jekyll-postcss will not use internal development conveniences when building on your host's servers.

--- a/README.md
+++ b/README.md
@@ -59,7 +59,9 @@ module.exports = {
 
 ### Caching
 
-Caching is enabled by default so PostCSS will only be called when the CSS content has changed. If needed you can disable caching in your Jekyll configuration to force the CSS to be recompiled every time:
+Caching is enabled by default so PostCSS will only be called when the CSS content has changed. If needed you can disable caching in your Jekyll configuration to force the CSS to be recompiled every time.
+
+If you are using the [TailwindCSS JIT](https://tailwindcss.com/docs/just-in-time-mode), you most likely need to disable the caching feature.
 
 ```yaml
 # _config.yml

--- a/bin/postcss
+++ b/bin/postcss
@@ -7,7 +7,7 @@ const net = require("net");
 class PostCSS {
   static process(data, write) {
     postcss(config.plugins)
-      .process(JSON.parse(data).raw_content, { from: "stdin" })
+      .process(JSON.parse(data).raw_content, { from: undefined })
       .then((result) => write(result))
       .catch((error) => {
         console.error("PostCSS Error!\n");

--- a/lib/jekyll/converters/postcss.rb
+++ b/lib/jekyll/converters/postcss.rb
@@ -32,7 +32,7 @@ module Jekyll
         @raw_digest = Digest::MD5.hexdigest content
         @raw_import_digests = import_digests(content)
 
-        if cache_miss.any?
+        if cache_miss?
           @raw_cache = @raw_digest.dup
           @import_raw_cache = @raw_import_digests.dup
 
@@ -58,10 +58,11 @@ module Jekyll
           end
       end
 
-      def cache_miss
+      def cache_miss?
         @raw_import_digests
           .map { |import, hash| @import_raw_cache[import] != hash }
           .unshift(@raw_cache != @raw_digest)
+          .any?
       end
 
       def reset

--- a/lib/jekyll/converters/postcss.rb
+++ b/lib/jekyll/converters/postcss.rb
@@ -12,6 +12,7 @@ module Jekyll
       def initialize(config = {})
         super
 
+        @cache_enabled = config.fetch("postcss", {}).fetch("cache", true)
         @socket = config.fetch("socket") { ::PostCss::Socket.new }
         @raw_cache = nil
         @import_raw_cache = {}
@@ -32,7 +33,7 @@ module Jekyll
         @raw_digest = Digest::MD5.hexdigest content
         @raw_import_digests = import_digests(content)
 
-        if cache_miss?
+        if cache_disabled? || cache_miss?
           @raw_cache = @raw_digest.dup
           @import_raw_cache = @raw_import_digests.dup
 
@@ -56,6 +57,10 @@ module Jekyll
             file = "#{import}.css"
             acc[import] = Digest::MD5.hexdigest IO.read(file) if File.file?(file)
           end
+      end
+
+      def cache_disabled?
+        @cache_enabled == false
       end
 
       def cache_miss?

--- a/spec/jekyll/postcss_spec.rb
+++ b/spec/jekyll/postcss_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Jekyll::Converters::PostCss do
     unconverted_content = "unchanged css"
 
     allow(Dir).to receive(:exist?).with("./node_modules/postcss") { true }
-    expect(@socket).to receive(:write) { unconverted_content }
+    expect(@socket).to receive(:write) { unconverted_content }.once
     expect(@socket).to receive(:read) { "cached css" }.once
 
     @converter.convert(unconverted_content)
@@ -96,5 +96,24 @@ RSpec.describe Jekyll::Converters::PostCss do
     result = @converter.convert(unconverted_content)
 
     expect(result).to eq("css")
+  end
+
+  context "with caching disabled" do
+    let(:configuration) do
+      Jekyll::Configuration::DEFAULTS.merge("postcss" => { "cache" => false })
+    end
+
+    it "recompiles the unchanged css if caching is disabled" do
+      unconverted_content = "unchanged css"
+
+      allow(Dir).to receive(:exist?).with("./node_modules/postcss") { true }
+      expect(@socket).to receive(:write) { unconverted_content }.twice
+      expect(@socket).to receive(:read) { "uncached css" }.twice
+
+      @converter.convert(unconverted_content)
+      result = @converter.convert(unconverted_content)
+
+      expect(result).to eq("uncached css")
+    end
   end
 end


### PR DESCRIPTION
Caching the compiled CSS makes sense 99% of the time, but I recently ran into a situation where it's better to have it disabled: Using [TailwindCSS](https://tailwindcss.com) in [JIT mode](https://tailwindcss.com/docs/just-in-time-mode). Jekyll will recompile the CSS every time any file is changed, but the caching is preventing TailwindCSS from running to actually update the CSS.

An overview of what happens in this case with caching enabled might help explain it better:

1. Jekyll is started and PostCSS runs, compiling and caching the CSS.
2. You change a class name in an HTML file.
3. Jekyll recompiles the HTML and CSS, but PostCSS is not run and the cached CSS is used.
4. The new class name has no effect since it's not added to the CSS.

#### Other Changes

I included two other small changes, one is a bug fix for using TailwindCSS and one is a small tweak:

- I removed the `stdin` source in `bin/postcss`. This was throwing an error when using TailwindCSS. A workaround is to create an `stdin` file in the root, but this seems more sane. This fixes #22. (See [5fa94692](https://github.com/mhanberg/jekyll-postcss/commit/5fa94692a0ab7abe25755cd79138afce94b6b529)).
- I slightly tweaked the `cache_miss` method to help it read a bit better with the cache disabled condition.

Let me know if you'd prefer the the `bin/postcss` as a separate PR and I can split them up.