### PR TITLE
Update Readme with "Alternatives"

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Your stylesheets still need to have [front matter](https://jekyllrb.com/docs/ste
 ## Alternatives 
 
 - [postcss-jekyll-v2](https://github.com/bglw/jekyll-postcss-v2): works well with TailwindCSS 2.0  
-- [bridgetown](https://github.com/bridgetownrb/bridgetown) - A Jekyll fork, which uses Weback for modern JS and CSS and is actively maintained. 
+- [bridgetown](https://github.com/bridgetownrb/bridgetown) - A Jekyll fork, which uses Webpack for modern JS and CSS and is actively maintained. 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -111,8 +111,8 @@ Your stylesheets still need to have [front matter](https://jekyllrb.com/docs/ste
 
 ## Alternatives 
 
-To use Jekyll with Tailwindcss v2, the new [postcss-jekyll-v2](https://github.com/bglw/jekyll-postcss-v2) is probably a better choice.  
-Instead of Jekyll, you may want to look into [bridgetown](https://github.com/bridgetownrb/bridgetown). It’s a Jekyll fork, which uses webpack for modern js and css. It is actively maintained.  
+- [postcss-jekyll-v2](https://github.com/bglw/jekyll-postcss-v2): works well with TailwindCSS 2.0  
+[bridgetown](https://github.com/bridgetownrb/bridgetown) - A Jekyll fork, which uses Weback for modern JS and CSS and is actively maintained. 
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Your stylesheets still need to have [front matter](https://jekyllrb.com/docs/ste
 ```
 
 ## Alternatives 
+
 To use Jekyll with Tailwindcss v2, the new [postcss-jekyll-v2](https://github.com/bglw/jekyll-postcss-v2) is probably a better choice.  
 Instead of Jekyll, you may want to look into [bridgetown](https://github.com/bridgetownrb/bridgetown). It’s a Jekyll fork, which uses webpack for modern js and css. It is actively maintained.  
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,10 @@ Your stylesheets still need to have [front matter](https://jekyllrb.com/docs/ste
 @tailwind utilities;
 ```
 
+## Alternatives 
+To use Jekyll with Tailwindcss v2, the new [postcss-jekyll-v2](https://github.com/bglw/jekyll-postcss-v2) is probably a better choice.  
+Instead of Jekyll, you may want to look into [bridgetown](https://github.com/bridgetownrb/bridgetown). It’s a Jekyll fork, which uses webpack for modern js and css. It is actively maintained.  
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake spec` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Your stylesheets still need to have [front matter](https://jekyllrb.com/docs/ste
 ## Alternatives 
 
 - [postcss-jekyll-v2](https://github.com/bglw/jekyll-postcss-v2): works well with TailwindCSS 2.0  
-[bridgetown](https://github.com/bridgetownrb/bridgetown) - A Jekyll fork, which uses Weback for modern JS and CSS and is actively maintained. 
+- [bridgetown](https://github.com/bridgetownrb/bridgetown) - A Jekyll fork, which uses Weback for modern JS and CSS and is actively maintained. 
 
 ## Development
 


### PR DESCRIPTION
Referencing alternative solutions.
- the jekyll-postcss-v2 gem works well with Tailwindcss 2
- Bridgetown is a Jekyll fork, and is actively maintained.